### PR TITLE
consistent return value for build number

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function resolveBuildNumber(params){
     if(typeof(params.buildnum) !== 'number'){
         return findLatestBuild(params);
     } else {
-        return Promise.resolve(params);
+        return Promise.resolve(params.buildnum);
     }
 }
 


### PR DESCRIPTION
The `resolveBuildNumber` has been updated to always retrieve the build number.

Before, when the build number was provided in the command line, the function would return the whole params, thus breaking the request.
